### PR TITLE
bump http version to 1.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 homepage: https://github.com/stafyniaksacha/mapbox-api
 
 dependencies:
-  http: ^0.13.0
+  http: ^1.2.0
 
 dev_dependencies:
   pedantic: ^1.9.2


### PR DESCRIPTION
Bumped http version to 1.2.0. Old one is conflicting with many packages now. Please let me know if you had a different approach in mind.