### PR TITLE
Update Navigation Enums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ doc/api/
 *.js_
 *.js.deps
 *.js.map
+
+.vscode/settings.json
+
+lib/.DS_Store
+
+.DS_Store

--- a/lib/src/navigation/globals.dart
+++ b/lib/src/navigation/globals.dart
@@ -50,13 +50,23 @@ enum NavigationStepMode {
 }
 
 enum NavigationInstructionType {
-  TURN,
-  MERGE,
-  DEPART,
   ARRIVE,
+  DEPART,
+  CONTINUE,
+  END_OF_ROAD,
   FORK,
+  MERGE,
+  NEW_NAME,
+  NOTIFICATION,
   OFF_RAMP,
+  ON_RAMP,
+  ROTARY,
   ROUNDABOUT,
+  TURN,
+  UPDOWN,
+  UTURN,
+  CLOSE,
+  FLAG,
 }
 
 enum NavigationInstructionModifier {
@@ -664,23 +674,59 @@ class NavigationInstructionProperty {
 
     if (json.containsKey('type') && json['type'] != null) {
       switch (json['type'] as String?) {
-        case 'turn':
-          type = NavigationInstructionType.TURN;
-          break;
-        case 'merge':
-          type = NavigationInstructionType.MERGE;
+        case 'arrive':
+          type = NavigationInstructionType.ARRIVE;
           break;
         case 'depart':
           type = NavigationInstructionType.DEPART;
           break;
+        case 'continue':
+          type = NavigationInstructionType.CONTINUE;
+          break;
+        case 'end of road':
+          type = NavigationInstructionType.END_OF_ROAD;
+          break;
         case 'fork':
           type = NavigationInstructionType.FORK;
+          break;
+        case 'merge':
+          type = NavigationInstructionType.MERGE;
+          break;
+        case 'new name':
+          type = NavigationInstructionType.NEW_NAME;
+          break;
+        case 'notification':
+          type = NavigationInstructionType.NOTIFICATION;
           break;
         case 'off ramp':
           type = NavigationInstructionType.OFF_RAMP;
           break;
+        case 'on ramp':
+          type = NavigationInstructionType.ON_RAMP;
+          break;
+        case 'rotary':
+          type = NavigationInstructionType.ROTARY;
+          break;
         case 'roundabout':
           type = NavigationInstructionType.ROUNDABOUT;
+          break;
+        case 'turn':
+          type = NavigationInstructionType.TURN;
+          break;
+        case 'updown':
+          type = NavigationInstructionType.UPDOWN;
+          break;
+        case 'uturn':
+          type = NavigationInstructionType.UTURN;
+          break;
+        case 'close':
+          type = NavigationInstructionType.CLOSE;
+          break;
+        case 'flag':
+          type = NavigationInstructionType.FLAG;
+          break;
+        default:
+          print('Unknown type: ${json['type']}');
           break;
       }
     }
@@ -690,23 +736,29 @@ class NavigationInstructionProperty {
         case 'uturn':
           modifier = NavigationInstructionModifier.UTURN;
           break;
-        case 'sharp_right':
+        case 'sharp right':
           modifier = NavigationInstructionModifier.SHARP_RIGHT;
           break;
-        case 'slight_right':
+        case 'right':
+          modifier = NavigationInstructionModifier.RIGHT;
+          break;
+        case 'slight right':
           modifier = NavigationInstructionModifier.SLIGHT_RIGHT;
           break;
         case 'straight':
           modifier = NavigationInstructionModifier.STRAIGHT;
           break;
-        case 'slight_left':
+        case 'slight left':
           modifier = NavigationInstructionModifier.SLIGHT_LEFT;
           break;
         case 'left':
           modifier = NavigationInstructionModifier.LEFT;
           break;
-        case 'sharp_left':
+        case 'sharp left':
           modifier = NavigationInstructionModifier.SHARP_LEFT;
+          break;
+        default:
+          print('Unknown modifier: ${json['modifier']}');
           break;
       }
     }
@@ -955,29 +1007,33 @@ class NavigationManeuver {
         case 'uturn':
           modifier = NavigationManeuverModifier.UTURN;
           break;
-        case 'sharp_right':
+        case 'sharp right':
           modifier = NavigationManeuverModifier.SHARP_RIGHT;
           break;
         case 'right':
           modifier = NavigationManeuverModifier.RIGHT;
           break;
-        case 'slight_right':
+        case 'slight right':
           modifier = NavigationManeuverModifier.SLIGHT_RIGHT;
           break;
         case 'straight':
           modifier = NavigationManeuverModifier.STRAIGHT;
           break;
-        case 'slight_left':
+        case 'slight left':
           modifier = NavigationManeuverModifier.SLIGHT_LEFT;
           break;
         case 'left':
           modifier = NavigationManeuverModifier.LEFT;
           break;
-        case 'sharp_left':
+        case 'sharp left':
           modifier = NavigationManeuverModifier.SHARP_LEFT;
+          break;
+        default:
+          print('Unknown modifier: ${json['modifier']}');
           break;
       }
     }
+
     if (json.containsKey('type') && json['type'] != null) {
       switch (json['type'] as String?) {
         case 'arrive':
@@ -1030,6 +1086,9 @@ class NavigationManeuver {
           break;
         case 'flag':
           type = NavigationManeuverType.FLAG;
+          break;
+        default:
+          print('Unknown type: ${json['type']}');
           break;
       }
     }

--- a/lib/src/navigation/globals.dart
+++ b/lib/src/navigation/globals.dart
@@ -123,22 +123,23 @@ enum NavigationManeuverModifier {
 }
 
 enum NavigationManeuverType {
-  TURN,
-  NEW_NAME,
-  DEPART,
   ARRIVE,
-  MERGE,
-  ON_RAMP,
-  OFF_RAMP,
-  FORK,
-  END_OF_ROAD,
+  DEPART,
   CONTINUE,
-  ROUNDABOUT,
-  ROTARY,
-  ROUNDABOUT_TURN,
+  END_OF_ROAD,
+  FORK,
+  MERGE,
+  NEW_NAME,
   NOTIFICATION,
-  EXIT_ROUNDABOUT,
-  EXIT_ROTARY,
+  OFF_RAMP,
+  ON_RAMP,
+  ROTARY,
+  ROUNDABOUT,
+  TURN,
+  UPDOWN,
+  UTURN,
+  CLOSE,
+  FLAG,
 }
 
 enum NavigationDestination {
@@ -960,72 +961,75 @@ class NavigationManeuver {
         case 'right':
           modifier = NavigationManeuverModifier.RIGHT;
           break;
-        case 'slap_right':
+        case 'slight_right':
           modifier = NavigationManeuverModifier.SLIGHT_RIGHT;
           break;
-        case 'sharp_left':
-          modifier = NavigationManeuverModifier.SHARP_LEFT;
+        case 'straight':
+          modifier = NavigationManeuverModifier.STRAIGHT;
+          break;
+        case 'slight_left':
+          modifier = NavigationManeuverModifier.SLIGHT_LEFT;
           break;
         case 'left':
           modifier = NavigationManeuverModifier.LEFT;
           break;
-        case 'slap_left':
-          modifier = NavigationManeuverModifier.SLIGHT_LEFT;
-          break;
-        case 'straight':
-          modifier = NavigationManeuverModifier.STRAIGHT;
+        case 'sharp_left':
+          modifier = NavigationManeuverModifier.SHARP_LEFT;
           break;
       }
     }
     if (json.containsKey('type') && json['type'] != null) {
       switch (json['type'] as String?) {
-        case 'turn':
-          type = NavigationManeuverType.TURN;
-          break;
-        case 'new name':
-          type = NavigationManeuverType.NEW_NAME;
+        case 'arrive':
+          type = NavigationManeuverType.ARRIVE;
           break;
         case 'depart':
           type = NavigationManeuverType.DEPART;
           break;
-        case 'arrive':
-          type = NavigationManeuverType.ARRIVE;
-          break;
-        case 'merge':
-          type = NavigationManeuverType.MERGE;
-          break;
-        case 'on ramp':
-          type = NavigationManeuverType.ON_RAMP;
-          break;
-        case 'off ramp':
-          type = NavigationManeuverType.OFF_RAMP;
-          break;
-        case 'fork':
-          type = NavigationManeuverType.FORK;
+        case 'continue':
+          type = NavigationManeuverType.CONTINUE;
           break;
         case 'end of road':
           type = NavigationManeuverType.END_OF_ROAD;
           break;
-        case 'continue':
-          type = NavigationManeuverType.CONTINUE;
+        case 'fork':
+          type = NavigationManeuverType.FORK;
           break;
-        case 'roundabout':
-          type = NavigationManeuverType.ROUNDABOUT;
+        case 'merge':
+          type = NavigationManeuverType.MERGE;
           break;
-        case 'rotary':
-          type = NavigationManeuverType.ROTARY;
-          break;
-        case 'roundabout turn':
-          type = NavigationManeuverType.ROUNDABOUT_TURN;
+        case 'new name':
+          type = NavigationManeuverType.NEW_NAME;
           break;
         case 'notification':
           type = NavigationManeuverType.NOTIFICATION;
           break;
-        case 'exit roundabout':
-          type = NavigationManeuverType.EXIT_ROUNDABOUT;
+        case 'off ramp':
+          type = NavigationManeuverType.OFF_RAMP;
           break;
-        case 'exit rotary':
-          type = NavigationManeuverType.EXIT_ROTARY;
+        case 'on ramp':
+          type = NavigationManeuverType.ON_RAMP;
+          break;
+        case 'rotary':
+          type = NavigationManeuverType.ROTARY;
+          break;
+        case 'roundabout':
+          type = NavigationManeuverType.ROUNDABOUT;
+          break;
+        case 'turn':
+          type = NavigationManeuverType.TURN;
+          break;
+        case 'updown':
+          type = NavigationManeuverType.UPDOWN;
+          break;
+        case 'uturn':
+          type = NavigationManeuverType.UTURN;
+          break;
+        case 'close':
+          type = NavigationManeuverType.CLOSE;
+          break;
+        case 'flag':
+          type = NavigationManeuverType.FLAG;
           break;
       }
     }


### PR DESCRIPTION
Added new values to the navigation maneuver types and modifiers for better handling of various driving scenarios. Cleaned up the .gitignore file by adding entries for IDE settings and system files.

- Added 'CONTINUE', 'END_OF_ROAD', 'FORK' to NavigationManeuverType
- Added 'UPDOWN', 'UTURN', 'CLOSE', 'FLAG' to NavigationManeuverModifier
- Removed redundant cases in switch statements
- Updated .gitignore to exclude IDE settings and system files

I have based the updates based on the navigation icon set that mapbox provides: https://miro.medium.com/v2/resize:fit:1400/format:webp/0*kmax3T3hU80xV6na.jpg